### PR TITLE
Fixed form action url

### DIFF
--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<form class="password-form" action="/wp-login.php?action=postpass" method="post">
+	<form class="password-form" action="{{site.link}}/wp-login.php?action=postpass" method="post">
 		<label for="pwbox-{{post.ID}}">Password:</label>
 		<input class="password-box" name="post_password" id="pwbox-{{post.ID}}" type="password" placeholder="Password" size="20" maxlength="20" />
 		<input class="password-btn" type="submit" name="Submit" value="Submit" />


### PR DESCRIPTION
This was broken for websites not existing at the root of a domain. Adding {{site.link}} fixes this