### PR TITLE
Changed protocol of wpackagist to https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     }
   ],
   "extra": {


### PR DESCRIPTION
Prevents an error being thrown on `composer install` with the latest version.