### PR TITLE
Removed X-UA-Compatible chrome frame

### DIFF
--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -15,7 +15,7 @@
     <meta name="description" content="{{site.description}}">
     <link rel="stylesheet" href="{{site.theme.link}}/style.css" type="text/css" media="screen" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="pingback" href="{{site.pingback_url}}" />
     {{function('wp_head')}}


### PR DESCRIPTION
Removed chrome=1 from X-UA-Compatible meta tag to fix w3 validation error.  

The tag was originally intended to signal IE browsers to render the page with the [Chrome Frame plugin](https://www.chromium.org/developers/how-tos/chrome-frame-getting-started) if installed.  Chrome Frame has been discontinued since early 2014 and only works with up to IE9, so I think we can safely get rid of the tag.