### PR TITLE
Add condition to check if menu exists

### DIFF
--- a/templates/menu.twig
+++ b/templates/menu.twig
@@ -1,8 +1,10 @@
-<ul>
-{% for item in menu %}
-	<li class="{{item.classes | join(' ')}}">
-		<a href="{{item.get_link}}">{{item.title}}</a>
-		{% include "menu.twig" with {'menu': item.get_children} %}
-	</li>
-{% endfor %}
-</ul>
+{% if menu %}
+	<ul>
+	{% for item in menu %}
+		<li class="{{item.classes | join(' ')}}">
+			<a href="{{item.get_link}}">{{item.title}}</a>
+			{% include "menu.twig" with {'menu': item.get_children} %}
+		</li>
+	{% endfor %}
+	</ul>
+{% endif %}


### PR DESCRIPTION
I added a condition to check if the Twig variable `{{ menu }}` is not empty, to avoid empty `<ul>` in menu items with no descendants.