### PR TITLE
Timber activation test with 'template_include filter'

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,8 +2,13 @@
 
 if ( ! class_exists( 'Timber' ) ) {
 	add_action( 'admin_notices', function() {
-			echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="' . esc_url( admin_url( 'plugins.php#timber' ) ) . '">' . esc_url( admin_url( 'plugins.php' ) ) . '</a></p></div>';
-		} );
+		echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="' . esc_url( admin_url( 'plugins.php#timber' ) ) . '">' . esc_url( admin_url( 'plugins.php') ) . '</a></p></div>';
+	});
+	
+	add_filter('template_include', function($template) {
+		return get_stylesheet_directory() . '/no-timber.php';
+	});
+	
 	return;
 }
 

--- a/index.php
+++ b/index.php
@@ -13,10 +13,6 @@
  * @since   Timber 0.1
  */
 
-if ( ! class_exists( 'Timber' ) ) {
-	echo 'Timber not activated. Make sure you activate the plugin in <a href="/wp-admin/plugins.php#timber">/wp-admin/plugins.php</a>';
-	return;
-}
 $context = Timber::get_context();
 $context['posts'] = Timber::get_posts();
 $context['foo'] = 'bar';

--- a/no-timber.php
+++ b/no-timber.php
@@ -1,0 +1,10 @@
+<!doctype html>
+
+<head>
+	<title>Timber not active</title>
+</head>
+
+<body>
+	<p>Timber not activated</p>
+</body>
+</html>


### PR DESCRIPTION
Prevents server errors on the front end without adding extra checks in php template files, but hijacking the requested template to a `no-timber.php` template.
