### PR TITLE
Added link target to menu template

### DIFF
--- a/templates/menu.twig
+++ b/templates/menu.twig
@@ -1,8 +1,8 @@
 {% if menu %}
 	<ul>
 	{% for item in menu %}
-		<li class="{{item.classes | join(' ')}}">
-			<a target="{{item.target}}" href="{{item.get_link}}">{{item.title}}</a>
+		<li class="{{ item.classes | join(' ') }}">
+			<a target="{{ item.target }}" href="{{ item.link }}">{{ item.title }}</a>
 			{% include "menu.twig" with {'menu': item.get_children} %}
 		</li>
 	{% endfor %}

--- a/templates/menu.twig
+++ b/templates/menu.twig
@@ -2,7 +2,7 @@
 	<ul>
 	{% for item in menu %}
 		<li class="{{item.classes | join(' ')}}">
-			<a href="{{item.get_link}}">{{item.title}}</a>
+			<a target="{{item.target}}" href="{{item.get_link}}">{{item.title}}</a>
 			{% include "menu.twig" with {'menu': item.get_children} %}
 		</li>
 	{% endfor %}


### PR DESCRIPTION
With this code addition the Wordpress "link target" tickbox to be found in the appearance->Menu overview, hidden under screensettings, works as expected and opens an link in a new tab (if selected so in the backend)