### PR TITLE
Update get_preview to new PostPreview API

### DIFF
--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
 	<h2 class="h2"><a href="{{post.link}}">{{post.title}}</a></h2>
-		<p>{{post.get_preview(25)}}</p>
+		<p>{{post.preview.length(25)}}</p>
 		{% if post.thumbnail.src %}
 			<img src="{{post.thumbnail.src}}" />
 		{% endif %}

--- a/templates/tease.twig
+++ b/templates/tease.twig
@@ -1,7 +1,7 @@
 <article class="tease tease-{{post.post_type}}" id="tease-{{post.ID}}">
 	{% block content %}
 		<h2 class="h2"><a href="{{post.link}}">{{post.title}}</a></h2>
-		<p>{{post.get_preview}}</p>
+		<p>{{post.preview}}</p>
 		{% if post.get_thumbnail %}
 			<img src="{{post.thumbnail.src}}" />
 		{% endif %}


### PR DESCRIPTION
In the spirit of #hacktoberfest, I figured I would contribute back to my favorite WP plugin!

This one is pretty simple but I ran into it the other day. Just updating the tease views to use `post.preview` instead of the now deprecated `post.get_preview`.