### PR TITLE
Switch to site.site_url for post password form action, over site.link

### DIFF
--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -1,7 +1,7 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<form class="password-form" action="{{site.link}}/wp-login.php?action=postpass" method="post">
+	<form class="password-form" action="{{site.site_url}}/wp-login.php?action=postpass" method="post">
 		<label for="pwbox-{{post.ID}}">Password:</label>
 		<input class="password-box" name="post_password" id="pwbox-{{post.ID}}" type="password" placeholder="Password" size="20" maxlength="20" />
 		<input class="password-btn" type="submit" name="Submit" value="Submit" />


### PR DESCRIPTION
When Wordpress is installed in a subdirectory, using `{{ site.link }}` results in an incorrect path to `wp-login.php`. `{{site.site_url}}` results in a correct link regardless of the Wordpress location.