### PR TITLE
Add better comments to show that auto escape is false by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,9 +20,22 @@ if ( ! class_exists( 'Timber' ) ) {
 	return;
 }
 
+/**
+ * Sets the directories (inside your theme) to find .twig files
+ */
 Timber::$dirname = array( 'templates', 'views' );
-/** Start Timber! */
 
+/**
+ * By default, Timber does NOT autoescape values. Want to enable Twig's autoescape? 
+ * No prob! Just set this value to true
+ */
+Timber::$autoescape = false;
+
+
+/**
+ * We're going to configure our theme inside of a subclass of Timber\Site
+ * You can move this to its own file and include here via php's include("MySite.php")
+ */
 class StarterSite extends Timber\Site {
 	/** Add timber support. */
 	public function __construct() {


### PR DESCRIPTION
This is a resolution to an issue on the main repo:

https://github.com/timber/timber/issues/1557

After much hand wringing, the conclusion we came to was "document the hell out of it" and make it very clear in the start theme what the default is, and how to change it