### PR TITLE
Avoid overriding the WP global $post object to improve compatibility

### DIFF
--- a/page.php
+++ b/page.php
@@ -24,4 +24,4 @@
 $context = Timber::get_context();
 $timber_post = new TimberPost();
 $context['post'] = $timber_post;
-Timber::render( array( 'page-' . $post->post_name . '.twig', 'page.twig' ), $context );
+Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );

--- a/page.php
+++ b/page.php
@@ -22,6 +22,6 @@
  */
 
 $context = Timber::get_context();
-$post = new TimberPost();
-$context['post'] = $post;
+$timber_post = new TimberPost();
+$context['post'] = $timber_post;
 Timber::render( array( 'page-' . $post->post_name . '.twig', 'page.twig' ), $context );

--- a/single.php
+++ b/single.php
@@ -10,8 +10,8 @@
  */
 
 $context = Timber::get_context();
-$post = Timber::query_post();
-$context['post'] = $post;
+$timber_post = Timber::query_post();
+$context['post'] = $timber_post;
 
 if ( post_password_required( $post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );

--- a/single.php
+++ b/single.php
@@ -13,8 +13,8 @@ $context = Timber::get_context();
 $timber_post = Timber::query_post();
 $context['post'] = $timber_post;
 
-if ( post_password_required( $post->ID ) ) {
+if ( post_password_required( $timber_post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );
 } else {
-	Timber::render( array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context );
+	Timber::render( array( 'single-' . $timber_post->ID . '.twig', 'single-' . $timber_post->post_type . '.twig', 'single.twig' ), $context );
 }


### PR DESCRIPTION
Related to [this issue](https://github.com/timber/starter-theme/issues/78)