### PR TITLE
update two twig calls in functions.php to namespaced variants

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,7 +11,7 @@
 /**
  * If you are installing Timber as a Composer dependency in your theme, you'll need this block
  * to load your dependencies and initialize Timber. If you are using Timber via the WordPress.org
- * plug-in, you can safely delete this block. 
+ * plug-in, you can safely delete this block.
  */
 $composer_autoload = __DIR__ . '/vendor/autoload.php';
 if ( file_exists($composer_autoload) ) {
@@ -149,8 +149,8 @@ class StarterSite extends Timber\Site {
 	 * @param string $twig get extension.
 	 */
 	public function add_to_twig( $twig ) {
-		$twig->addExtension( new Twig_Extension_StringLoader() );
-		$twig->addFilter( new Twig_SimpleFilter( 'myfoo', array( $this, 'myfoo' ) ) );
+		$twig->addExtension( new Twig\Extension\StringLoaderExtension() );
+		$twig->addFilter( new Twig\TwigFilter( 'myfoo', array( $this, 'myfoo' ) ) );
 		return $twig;
 	}
 


### PR DESCRIPTION
Fixes : `"Using the "Twig_Extension_StringLoader" class is deprecated since Twig version 2.7, use "Twig\Extension\StringLoaderExtension" instead."`

Not sure if these need a `class_exists` check and fallback to the old naming? Feedback welcome!