### PR TITLE
Update single-password.twig

### DIFF
--- a/templates/single-password.twig
+++ b/templates/single-password.twig
@@ -1,9 +1,10 @@
 {% extends "base.twig" %}
 
 {% block content %}
-	<form class="password-form" action="{{site.site_url}}/wp-login.php?action=postpass" method="post">
+	<form class="password-form" action="{{ function('site_url', 'wp-login.php', 'login_post') }}" method="post">
 		<label for="pwbox-{{post.ID}}">Password:</label>
 		<input class="password-box" name="post_password" id="pwbox-{{post.ID}}" type="password" placeholder="Password" size="20" maxlength="20" />
-		<input class="password-btn" type="submit" name="Submit" value="Submit" />
+		<input type="hidden" name="action" value="postpass" />
+		<button class="btn" type="submit" name="Submit" />Submit</button>
 	</form>
 {% endblock %}


### PR DESCRIPTION
Some Managed WordPress hosting companies (WP Engine 👀) modify the wp-login URL for security reasons. Generating the login URL the way WordPress does prevents these issues. More info here: https://wpengine.com/support/error/#444_-_Connection_Closed_Without_A_Response