### PR TITLE
Use v2 API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "timber/timber": "dev-2.x-term-factories"
+    "timber/timber": "2.x-dev"
   },
   "require-dev": {
     "phpunit/phpunit": "7.*",

--- a/theme/archive.php
+++ b/theme/archive.php
@@ -35,6 +35,6 @@ if ( is_day() ) {
 	array_unshift( $templates, 'archive-' . get_post_type() . '.twig' );
 }
 
-$context['posts'] = new Timber\PostQuery();
+$context['posts'] = Timber::get_posts();
 
 Timber::render( $templates, $context );

--- a/theme/author.php
+++ b/theme/author.php
@@ -12,9 +12,9 @@
 global $wp_query;
 
 $context          = Timber::context();
-$context['posts'] = new Timber\PostQuery();
+$context['posts'] = Timber::get_posts();
 if ( isset( $wp_query->query_vars['author'] ) ) {
-	$author            = new Timber\User( $wp_query->query_vars['author'] );
+	$author            = Timber::get_user( $wp_query->query_vars['author'] );
 	$context['author'] = $author;
 	$context['title']  = 'Author Archives: ' . $author->name();
 }

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -16,7 +16,7 @@
 $composer_autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
 if ( file_exists( $composer_autoload ) ) {
 	require_once $composer_autoload;
-	$timber = new Timber\Timber();
+	Timber\Timber::init();
 }
 
 /**

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -84,7 +84,7 @@ class StarterSite extends Timber\Site {
 		$context['foo']   = 'bar';
 		$context['stuff'] = 'I am a value set in your functions.php file';
 		$context['notes'] = 'These values are available everytime you call Timber::context();';
-		$context['menu']  = new Timber\Menu();
+		$context['menu']  = Timber::get_menu();
 		$context['site']  = $this;
 		return $context;
 	}

--- a/theme/index.php
+++ b/theme/index.php
@@ -14,7 +14,7 @@
  */
 
 $context          = Timber::context();
-$context['posts'] = new Timber\PostQuery();
+$context['posts'] = Timber::get_posts();
 $context['foo']   = 'bar';
 $templates        = array( 'index.twig' );
 if ( is_home() ) {

--- a/theme/page.php
+++ b/theme/page.php
@@ -23,6 +23,6 @@
 
 $context = Timber::context();
 
-$timber_post     = new Timber\Post();
+$timber_post     = Timber::get_post();
 $context['post'] = $timber_post;
 Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );

--- a/theme/search.php
+++ b/theme/search.php
@@ -13,6 +13,6 @@ $templates = array( 'search.twig', 'archive.twig', 'index.twig' );
 
 $context          = Timber::context();
 $context['title'] = 'Search results for ' . get_search_query();
-$context['posts'] = new Timber\PostQuery();
+$context['posts'] = Timber::get_posts();
 
 Timber::render( $templates, $context );

--- a/theme/single.php
+++ b/theme/single.php
@@ -10,7 +10,7 @@
  */
 
 $context         = Timber::context();
-$timber_post     = Timber::query_post();
+$timber_post     = Timber::get_post();
 $context['post'] = $timber_post;
 
 if ( post_password_required( $timber_post->ID ) ) {


### PR DESCRIPTION
Replaces the deprecated class and functions. As is, the 2.x branch doesn't initialize properly or follow 2.x convention.

https://timber.github.io/docs/v2/upgrade-guides/2.0/