### PR TITLE
Point Timber package to a matching version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "timber/timber": "dev-2.x-term-factories"
+    "timber/timber": "2.x-dev"
   },
   "require-dev": {
     "phpunit/phpunit": "7.*",


### PR DESCRIPTION
Hi,

i've noticed the composer.json was slightly outdated and due to that it was pointing to version of the timber package which doesn't exist anymore, i've pushed the following commit to address that.

Thank you,
Cezar