### PR TITLE
fix: remove sidebar_class as undefined variable

### DIFF
--- a/views/base.twig
+++ b/views/base.twig
@@ -24,7 +24,7 @@
 
 		<section id="content" role="main" class="content-wrapper">
 			{% if title %}<h1>{{title}}</h1>{% endif %}
-			<div class="wrapper {{sidebar_class}}">
+			<div class="wrapper">
 				{% block content %}
 					Sorry, no content
 				{% endblock %}


### PR DESCRIPTION
Removed unused variable from base.twig. It seems not to be defined anywhere.