### PR TITLE
feat: rework of PHP files.

### DIFF
--- a/404.php
+++ b/404.php
@@ -4,7 +4,7 @@
  * The template for the 404 page
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/404.php
+++ b/404.php
@@ -1,13 +1,12 @@
 <?php
+
 /**
- * The template for displaying 404 pages (Not Found)
- *
- * Methods for TimberHelper can be found in the /functions sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since    Timber 0.1
+ * The template for the 404 page
  */
 
+namespace Timber\StarterTheme;
+
+use Timber\Timber;
+
 $context = Timber::context();
-Timber::render( '404.twig', $context );
+Timber::render('404.twig', $context);

--- a/archive.php
+++ b/archive.php
@@ -10,7 +10,7 @@
  *
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/archive.php
+++ b/archive.php
@@ -16,8 +16,6 @@ use Timber\Timber;
 
 $templates = array('archive.twig', 'index.twig');
 
-$context = Timber::context();
-
 $title = 'Archive';
 if (is_day()) {
 	$title = 'Archive: ' . get_the_date('D M Y');
@@ -35,9 +33,8 @@ if (is_day()) {
 	array_unshift($templates, 'archive-' . get_post_type() . '.twig');
 }
 
-$posts = Timber::get_posts();
-
-Timber::render($templates, [
+$context = Timber::context([
 	'title' => $title,
-	'posts' => $posts,
 ]);
+
+Timber::render($templates, $context);

--- a/archive.php
+++ b/archive.php
@@ -1,40 +1,43 @@
 <?php
+
 /**
  * The template for displaying Archive pages.
  *
  * Used to display archive-type pages if nothing more specific matches a query.
  * For example, puts together date-based pages if no date.php file exists.
  *
- * Learn more: http://codex.wordpress.org/Template_Hierarchy
+ * Learn more: https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since   Timber 0.2
  */
 
-$templates = array( 'archive.twig', 'index.twig' );
+namespace Timber\StarterTheme;
+
+use Timber\Timber;
+
+$templates = array('archive.twig', 'index.twig');
 
 $context = Timber::context();
 
-$context['title'] = 'Archive';
-if ( is_day() ) {
-	$context['title'] = 'Archive: ' . get_the_date( 'D M Y' );
-} elseif ( is_month() ) {
-	$context['title'] = 'Archive: ' . get_the_date( 'M Y' );
-} elseif ( is_year() ) {
-	$context['title'] = 'Archive: ' . get_the_date( 'Y' );
-} elseif ( is_tag() ) {
-	$context['title'] = single_tag_title( '', false );
-} elseif ( is_category() ) {
-	$context['title'] = single_cat_title( '', false );
-	array_unshift( $templates, 'archive-' . get_query_var( 'cat' ) . '.twig' );
-} elseif ( is_post_type_archive() ) {
-	$context['title'] = post_type_archive_title( '', false );
-	array_unshift( $templates, 'archive-' . get_post_type() . '.twig' );
+$title = 'Archive';
+if (is_day()) {
+	$title = 'Archive: ' . get_the_date('D M Y');
+} elseif (is_month()) {
+	$title = 'Archive: ' . get_the_date('M Y');
+} elseif (is_year()) {
+	$title = 'Archive: ' . get_the_date('Y');
+} elseif (is_tag()) {
+	$title = single_tag_title('', false);
+} elseif (is_category()) {
+	$title = single_cat_title('', false);
+	array_unshift($templates, 'archive-' . get_query_var('cat') . '.twig');
+} elseif (is_post_type_archive()) {
+	$title = post_type_archive_title('', false);
+	array_unshift($templates, 'archive-' . get_post_type() . '.twig');
 }
 
-$context['posts'] = Timber::get_posts();
+$posts = Timber::get_posts();
 
-Timber::render( $templates, $context );
+Timber::render($templates, [
+	'title' => $title,
+	'posts' => $posts,
+]);

--- a/author.php
+++ b/author.php
@@ -1,21 +1,28 @@
 <?php
+
 /**
  * The template for displaying Author Archive pages
  *
  * Methods for TimberHelper can be found in the /lib sub-directory
  *
- * @package  WordPress
- * @subpackage  Timber
- * @since    Timber 0.1
  */
+
+namespace Timber\StarterTheme;
+
+use Timber\Timber;
 
 global $wp_query;
 
-$context          = Timber::context();
-$context['posts'] = Timber::get_posts();
-if ( isset( $wp_query->query_vars['author'] ) ) {
-	$author            = Timber::get_user( $wp_query->query_vars['author'] );
-	$context['author'] = $author;
-	$context['title']  = 'Author Archives: ' . $author->name();
+$title = false;
+if (isset($wp_query->query_vars['author'])) {
+	$author = Timber::get_user($wp_query->query_vars['author']);
+	$title  = 'Author Archives: ' . $author->name();
 }
-Timber::render( array( 'author.twig', 'archive.twig' ), $context );
+
+$context = Timber::context([
+	'title'  => $title,
+	'posts'  => Timber::get_posts(),
+	'author' => $author,
+]);
+
+Timber::render(array('author.twig', 'archive.twig'), $context);

--- a/author.php
+++ b/author.php
@@ -21,7 +21,6 @@ if (isset($wp_query->query_vars['author'])) {
 
 $context = Timber::context([
 	'title'  => $title,
-	'posts'  => Timber::get_posts(),
 	'author' => $author,
 ]);
 

--- a/author.php
+++ b/author.php
@@ -7,7 +7,7 @@
  *
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/functions.php
+++ b/functions.php
@@ -17,7 +17,4 @@ require_once __DIR__ . '/src/StarterSite.php';
 
 Timber::init();
 
-// Sets the directories (inside your theme) to find .twig files.
-Timber::$dirname = ['templates', 'views'];
-
 new StarterSite();

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  * @link https://github.com/timber/starter-theme
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/functions.php
+++ b/functions.php
@@ -1,17 +1,23 @@
 <?php
+
 /**
- * Timber starter-theme
- * https://github.com/timber/starter-theme
+ * Functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ * @link https://github.com/timber/starter-theme
  */
+
+namespace Timber\StarterTheme;
+
+use Timber\Timber;
 
 // Load Composer dependencies.
 require_once __DIR__ . '/vendor/autoload.php';
-
 require_once __DIR__ . '/src/StarterSite.php';
 
-Timber\Timber::init();
+Timber::init();
 
 // Sets the directories (inside your theme) to find .twig files.
-Timber::$dirname = [ 'templates', 'views' ];
+Timber::$dirname = ['templates', 'views'];
 
 new StarterSite();

--- a/index.php
+++ b/index.php
@@ -1,23 +1,28 @@
 <?php
+
 /**
  * The main template file
+ *
  * This is the most generic template file in a WordPress theme
  * and one of the two required files for a theme (the other being style.css).
  * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists
+ * E.g., it puts together the home page when no home.php file exists.
  *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since   Timber 0.1
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  */
 
-$context          = Timber::context();
-$context['posts'] = Timber::get_posts();
-$context['foo']   = 'bar';
-$templates        = array( 'index.twig' );
-if ( is_home() ) {
-	array_unshift( $templates, 'front-page.twig', 'home.twig' );
+use Timber\Timber;
+
+$posts     = Timber::get_posts();
+$templates = array('index.twig');
+
+if (is_home()) {
+	array_unshift($templates, 'front-page.twig', 'home.twig');
 }
-Timber::render( $templates, $context );
+
+$context = Timber::context([
+	'posts' => $posts,
+	'foo'   => 'bar',
+]);
+
+Timber::render($templates, $context);

--- a/index.php
+++ b/index.php
@@ -13,7 +13,6 @@
 
 use Timber\Timber;
 
-$posts     = Timber::get_posts();
 $templates = array('index.twig');
 
 if (is_home()) {
@@ -21,7 +20,6 @@ if (is_home()) {
 }
 
 $context = Timber::context([
-	'posts' => $posts,
 	'foo'   => 'bar',
 ]);
 

--- a/page.php
+++ b/page.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The template for displaying all pages.
  *
@@ -7,22 +8,18 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
- * To generate specific templates for your pages you can use:
- * /mytheme/templates/page-mypage.twig
- * (which will still route through this PHP file)
- * OR
- * /mytheme/page-mypage.php
- * (in which case you'll want to duplicate this file and save to the above path)
- *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since    Timber 0.1
  */
 
-$context = Timber::context();
+namespace Timber\StarterTheme;
 
-$timber_post     = Timber::get_post();
-$context['post'] = $timber_post;
-Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );
+use Timber\Timber;
+
+$post = Timber::get_post();
+
+$context = Timber::context(
+   [
+      'post' => $post,
+   ]
+);
+
+Timber::render(array('page-' . $timber_post->post_name . '.twig', 'page.twig'), $context);

--- a/page.php
+++ b/page.php
@@ -10,7 +10,7 @@
  *
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/page.php
+++ b/page.php
@@ -14,12 +14,7 @@ namespace App;
 
 use Timber\Timber;
 
-$post = Timber::get_post();
+$context = Timber::context();
+$post = $context['post'];
 
-$context = Timber::context(
-   [
-      'post' => $post,
-   ]
-);
-
-Timber::render(array('page-' . $timber_post->post_name . '.twig', 'page.twig'), $context);
+Timber::render(array('page-' . $post->post_name . '.twig', 'page.twig'), $context);

--- a/search.php
+++ b/search.php
@@ -11,7 +11,6 @@ $templates = array('search.twig', 'archive.twig', 'index.twig');
 
 $context = Timber::context([
    'title' => 'Search results for ' . get_search_query(),
-   'posts' => Timber::get_posts(),
 ]);
 
 Timber::render($templates, $context);

--- a/search.php
+++ b/search.php
@@ -1,18 +1,17 @@
 <?php
+
 /**
  * Search results page
- *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since   Timber 0.1
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  */
 
-$templates = array( 'search.twig', 'archive.twig', 'index.twig' );
+use Timber\Timber;
 
-$context          = Timber::context();
-$context['title'] = 'Search results for ' . get_search_query();
-$context['posts'] = Timber::get_posts();
+$templates = array('search.twig', 'archive.twig', 'index.twig');
 
-Timber::render( $templates, $context );
+$context = Timber::context([
+   'title' => 'Search results for ' . get_search_query(),
+   'posts' => Timber::get_posts(),
+]);
+
+Timber::render($templates, $context);

--- a/single.php
+++ b/single.php
@@ -5,7 +5,7 @@
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  */
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Timber;
 

--- a/single.php
+++ b/single.php
@@ -1,20 +1,23 @@
 <?php
+
 /**
  * The Template for displaying all single posts
- *
- * Methods for TimberHelper can be found in the /lib sub-directory
- *
- * @package  WordPress
- * @subpackage  Timber
- * @since    Timber 0.1
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  */
 
-$context         = Timber::context();
-$timber_post     = Timber::get_post();
-$context['post'] = $timber_post;
+namespace Timber\StarterTheme;
 
-if ( post_password_required( $timber_post->ID ) ) {
-	Timber::render( 'single-password.twig', $context );
+use Timber\Timber;
+
+$post    = Timber::get_post();
+$context = Timber::context(
+	[
+		'post' => $post,
+	]
+);
+
+if (post_password_required($post->ID)) {
+	Timber::render('single-password.twig', $context);
 } else {
-	Timber::render( array( 'single-' . $timber_post->ID . '.twig', 'single-' . $timber_post->post_type . '.twig', 'single-' . $timber_post->slug . '.twig', 'single.twig' ), $context );
+	Timber::render(array('single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single-' . $post->slug . '.twig', 'single.twig'), $context);
 }

--- a/single.php
+++ b/single.php
@@ -9,12 +9,8 @@ namespace App;
 
 use Timber\Timber;
 
-$post    = Timber::get_post();
-$context = Timber::context(
-	[
-		'post' => $post,
-	]
-);
+$context = Timber::context();
+$post = $context['post'];
 
 if (post_password_required($post->ID)) {
 	Timber::render('single-password.twig', $context);

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -132,7 +132,7 @@ class StarterSite extends Site
 		 */
 		// $twig->addExtension( new Twig\Extension\StringLoaderExtension() );
 
-		$twig->addFilter(new Twig\TwigFilter('myfoo', [$this, 'myfoo']));
+		$twig->addFilter(new \Twig\TwigFilter('myfoo', [$this, 'myfoo']));
 
 		return $twig;
 	}

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -1,19 +1,24 @@
 <?php
 
+namespace Timber\StarterTheme;
+
 use Timber\Site;
+use Timber\Timber;
 
 /**
  * Class StarterSite
  */
-class StarterSite extends Site {
-	public function __construct() {
-		add_action( 'after_setup_theme', array( $this, 'theme_supports' ) );
-		add_action( 'init', array( $this, 'register_post_types' ) );
-		add_action( 'init', array( $this, 'register_taxonomies' ) );
+class StarterSite extends Site
+{
+	public function __construct()
+	{
+		add_action('after_setup_theme', array($this, 'theme_supports'));
+		add_action('init', array($this, 'register_post_types'));
+		add_action('init', array($this, 'register_taxonomies'));
 
-		add_filter( 'timber/context', array( $this, 'add_to_context' ) );
-		add_filter( 'timber/twig', array( $this, 'add_to_twig' ) );
-		add_filter( 'timber/twig/environment/options', [ $this, 'update_twig_environment_options' ] );
+		add_filter('timber/context', array($this, 'add_to_context'));
+		add_filter('timber/twig', array($this, 'add_to_twig'));
+		add_filter('timber/twig/environment/options', [$this, 'update_twig_environment_options']);
 
 		parent::__construct();
 	}
@@ -21,15 +26,15 @@ class StarterSite extends Site {
 	/**
 	 * This is where you can register custom post types.
 	 */
-	public function register_post_types() {
-
+	public function register_post_types()
+	{
 	}
 
 	/**
 	 * This is where you can register custom taxonomies.
 	 */
-	public function register_taxonomies() {
-
+	public function register_taxonomies()
+	{
 	}
 
 	/**
@@ -37,7 +42,8 @@ class StarterSite extends Site {
 	 *
 	 * @param string $context context['this'] Being the Twig's {{ this }}.
 	 */
-	public function add_to_context( $context ) {
+	public function add_to_context($context)
+	{
 		$context['foo']   = 'bar';
 		$context['stuff'] = 'I am a value set in your functions.php file';
 		$context['notes'] = 'These values are available everytime you call Timber::context();';
@@ -47,9 +53,10 @@ class StarterSite extends Site {
 		return $context;
 	}
 
-	public function theme_supports() {
+	public function theme_supports()
+	{
 		// Add default posts and comments RSS feed links to head.
-		add_theme_support( 'automatic-feed-links' );
+		add_theme_support('automatic-feed-links');
 
 		/*
 		 * Let WordPress manage the document title.
@@ -57,14 +64,14 @@ class StarterSite extends Site {
 		 * hard-coded <title> tag in the document head, and expect WordPress to
 		 * provide it for us.
 		 */
-		add_theme_support( 'title-tag' );
+		add_theme_support('title-tag');
 
 		/*
 		 * Enable support for Post Thumbnails on posts and pages.
 		 *
 		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
 		 */
-		add_theme_support( 'post-thumbnails' );
+		add_theme_support('post-thumbnails');
 
 		/*
 		 * Switch default core markup for search form, comment form, and comments
@@ -98,7 +105,7 @@ class StarterSite extends Site {
 			)
 		);
 
-		add_theme_support( 'menus' );
+		add_theme_support('menus');
 	}
 
 	/**
@@ -106,7 +113,8 @@ class StarterSite extends Site {
 	 *
 	 * @param string $text being 'foo', then returned 'foo bar!'.
 	 */
-	public function myfoo( $text ) {
+	public function myfoo($text)
+	{
 		$text .= ' bar!';
 		return $text;
 	}
@@ -116,14 +124,15 @@ class StarterSite extends Site {
 	 *
 	 * @param Twig\Environment $twig get extension.
 	 */
-	public function add_to_twig( $twig ) {
+	public function add_to_twig($twig)
+	{
 		/**
 		 * Required when you want to use Twig’s template_from_string.
 		 * @link https://twig.symfony.com/doc/3.x/functions/template_from_string.html
 		 */
 		// $twig->addExtension( new Twig\Extension\StringLoaderExtension() );
 
-		$twig->addFilter( new Twig\TwigFilter( 'myfoo', [ $this, 'myfoo' ] ) );
+		$twig->addFilter(new Twig\TwigFilter('myfoo', [$this, 'myfoo']));
 
 		return $twig;
 	}
@@ -137,9 +146,10 @@ class StarterSite extends Site {
 	 *
 	 * @return array
 	 */
-	function update_twig_environment_options( $options ) {
-	    // $options['autoescape'] = true;
+	function update_twig_environment_options($options)
+	{
+		// $options['autoescape'] = true;
 
-	    return $options;
+		return $options;
 	}
 }

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Timber\StarterTheme;
+namespace App;
 
 use Timber\Site;
 use Timber\Timber;


### PR DESCRIPTION
This is the first changes in a larger set of changes that I am going to propose.

<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #152
- #153 
- #154
- #155 
- #156
- #157
- #158 
- #159


## Issue
Since the creation of the starter theme a lot has happened in PHP, WordPress and Timber. I want to make the starter-theme a more modern starting point for custom theme development.

## Solution
This particular PR focusses on overhauling the PHP files to:

- Be namespaced
- Have less confusing docblocks
- Use the new way of passing context to the templates


## Impact
A better, less confusing, start with templating in Timber.


## Usage Changes
Code is now namespaced, so people will have to add filters/actions with a namespace reference as well. In a next PR I will also solely focus on the starttheme class.

## Considerations
This is not adhering to any code style yet, I would like to introduce that soon as well and thus lint the whole codebase.

## Testing
I might try to add some overall tests in the upcoming few PR's
