### PR TITLE
feat: remove sidebar

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * The Template for the sidebar containing the main widget area
- *
- * @package  WordPress
- * @subpackage  Timber
- */
-
-Timber::render( array( 'sidebar.twig' ), $data );

--- a/views/base.twig
+++ b/views/base.twig
@@ -29,11 +29,6 @@
 					Sorry, no content
 				{% endblock %}
 			</div>
-			{% if sidebar %}
-				<aside class="layout-sidebar">
-					{{sidebar}}
-				</aside>
-			{% endif %}
 		</section>
 
 		{% block footer %}

--- a/views/sidebar.twig
+++ b/views/sidebar.twig
@@ -1,1 +1,0 @@
-Sidebar in Timber. Add HTML to your hearts content.


### PR DESCRIPTION
Related:

- #152
- #153 
- #154
- #155 
- #156
- #157
- #158 
- #159


## Issue
Since the creation of the starter theme a lot has happened in PHP, WordPress and Timber. I want to make the starter-theme a more modern starting point for custom theme development.

## Solution
This particular PR focusses on deleting the sidebar files. Since Gutenberg is introduced, I rarely see widgets being used in the wild. With widgets getting deprecated, I think it is time to say farewell to the sidebar.

## Impact
No more sidebars, so cleaner code.

## Usage Changes
Minimal, I think when you create a new site nowaydays, developers are not using the sidebar/widgets functions that much. For the few folks that still stick to it, the can re-add this functionality in a way they see fit.

## Considerations
Not dumping the sidebar yet?

## Testing
I might try to add some overall tests in the upcoming few PR's
