### PR TITLE
Feat: update composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "timber/timber-starter-theme",
+  "name": "timber/starter-theme",
   "description": "Starter theme to build a Timber theme",
   "type":"wordpress-theme",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,32 @@
 {
-  "name": "upstatement/timber-starter-theme",
+  "name": "timber/timber-starter-theme",
   "description": "Starter theme to build a Timber theme",
   "type":"wordpress-theme",
   "license": "MIT",
   "authors": [
     {
+      "name": "Erik van der Bas",
+      "email": "erik@basedonline.nl",
+      "homepage": "https://basedonline.nl"
+    },
+    {
+      "name": "Lukas Gächter",
+      "email": "lukas.gaechter@mind.ch",
+      "homepage": "https://www.mind.ch"
+    },
+    {
+      "name": "Nicolas Lemoine",
+      "email": "nico@n5s.dev",
+      "homepage": "https://n5s.dev"
+    },
+    {
+      "name": "Jared Novack",
       "email": "jared@upstatement.com",
-      "name": "jarednova"
+      "homepage": "https://upstatement.com"
+    },
+    {
+      "name": "Timber Community",
+      "homepage": "https://github.com/timber/timber"
     }
   ],
   "repositories": [
@@ -16,7 +36,7 @@
     }
   ],
   "require": {
-    "timber/timber": "2.x-dev"
+    "timber/timber": "^2.1"
   },
   "require-dev": {
     "automattic/wordbless": "^0.4.2",


### PR DESCRIPTION
Related:

- #152
- #153 
- #154
- #155 
- #156
- #157
- #158 
- #159


## Issue
Since the creation of the starter theme a lot has happened in PHP, WordPress and Timber. I want to make the starter-theme a more modern starting point for custom theme development.

## Solution
This particular PR focusses on bringing the starter theme under the timber umbrella at packagist.org, set the authors and a non-dev version of Timber.

## Impact
Better composer file :D

## Usage Changes
No

## Considerations
Not moving the theme underneath the Timber account at packagist?

## Testing
no
