### PR TITLE
chore: cleanup license, rename and style.css

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2013 Jared Novack
+Copyright (c) 2012-2024 Timber team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Small tip: You can make use of Composer’s [autoloading functionality](https://
 
 ## Other Resources
 
-* [This branch](https://github.com/laras126/timber-starter-theme/tree/tackle-box) of the starter theme has some more example code with ACF and a slightly different set up.
-* [Twig for Timber Cheatsheet](http://notlaura.com/the-twig-for-timber-cheatsheet/)
+* [Twig for Timber Cheatsheet](https://notlaura.com/the-twig-for-timber-cheatsheet/)
 * [Timber and Twig Reignited My Love for WordPress](https://css-tricks.com/timber-and-twig-reignited-my-love-for-wordpress/) on CSS-Tricks
 * [A real live Timber theme](https://github.com/laras126/yuling-theme).
-* [Timber Video Tutorials](http://timber.github.io/timber/#video-tutorials) and [an incomplete set of screencasts](https://www.youtube.com/playlist?list=PLuIlodXmVQ6pkqWyR6mtQ5gQZ6BrnuFx-) for building a Timber theme from scratch.

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /*
  * Theme Name: My Timber 2.x Starter Theme
  * Description: Starter Theme to use with Timber
- * Author: Upstatement and YOU!
+ * Author: Timber Team and You!
 */


### PR DESCRIPTION
Related:

- #152
- #153 
- #154
- #155 
- #156
- #157
- #158 
- #159

## Issue
Since the creation of the starter theme a lot has happened in PHP, WordPress and Timber. I want to make the starter-theme a more modern starting point for custom theme development.

## Solution
This particular PR focusses on updating the readme, style.css and license a bit to mirror the fact that this is a Timber team effort!

## Impact
Minimal.

## Usage Changes
No

## Considerations
Not moving the theme underneath the Timber account at packagist?

## Testing
no
