### PR TITLE
feat: move style registration from template to StarterSite.php

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,1 @@
+/* Add your own styles here */

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -40,11 +40,12 @@ class StarterSite extends Site {
 	 * This enqueues theme styles.
 	 */
 	public function enqueue_styles() {
+		$main_stylesheet = '/assets/styles/main.css';
 		wp_enqueue_style(
 			'timber-starter-style',
-			get_template_directory_uri() . '/assets/styles/main.css',
+			get_template_directory_uri() . $main_stylesheet,
 			[],
-			filemtime( get_template_directory() . '/assets/styles/main.css' )
+			filemtime(get_template_directory() . $main_stylesheet)
 		);
 	}
 

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -26,6 +26,7 @@ class StarterSite extends Site {
 		add_action( 'after_setup_theme', [ $this, 'theme_supports' ] );
 		add_action( 'init', [ $this, 'register_post_types' ] );
 		add_action( 'init', [ $this, 'register_taxonomies' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_styles' ] );
 
 		add_filter( 'timber/context', [ $this, 'add_to_context' ] );
 		add_filter( 'timber/twig/filters', [ $this, 'add_filters_to_twig' ] );
@@ -33,6 +34,18 @@ class StarterSite extends Site {
 		add_filter( 'timber/twig/environment/options', [ $this, 'update_twig_environment_options' ] );
 
 		parent::__construct();
+	}
+
+	/**
+	 * This enqueues theme styles.
+	 */
+	public function enqueue_styles() {
+		wp_enqueue_style(
+			'timber-starter-style',
+			get_template_directory_uri() . '/style.css',
+			[],
+			filemtime( get_template_directory() . '/style.css' )
+		);
 	}
 
 	/**

--- a/src/StarterSite.php
+++ b/src/StarterSite.php
@@ -42,9 +42,9 @@ class StarterSite extends Site {
 	public function enqueue_styles() {
 		wp_enqueue_style(
 			'timber-starter-style',
-			get_template_directory_uri() . '/style.css',
+			get_template_directory_uri() . '/assets/styles/main.css',
 			[],
-			filemtime( get_template_directory() . '/style.css' )
+			filemtime( get_template_directory() . '/assets/styles/main.css' )
 		);
 	}
 

--- a/style.css
+++ b/style.css
@@ -2,4 +2,9 @@
  * Theme Name: My Timber 2.x Starter Theme
  * Description: Starter Theme to use with Timber
  * Author: Timber Team and You!
-*/
+ */
+
+/* NOTE:
+ * This file is reserved for the theme metadata and is not loaded.
+ * Write styles in assets/styles/main.css instead.
+ */

--- a/views/partials/head.twig
+++ b/views/partials/head.twig
@@ -1,6 +1,5 @@
 <head>
     <meta charset="{{ site.charset }}" />
-    <link rel="stylesheet" href="{{ site.theme.link }}/style.css" type="text/css" media="screen" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="author" href="{{ site.theme.link }}/humans.txt" />
     <link rel="profile" href="http://gmpg.org/xfn/11" />


### PR DESCRIPTION
- [Ticket 1](https://github.com/timber/starter-theme/issues/160)

Style version which is useful for cache busting is set to use the `style.css` file's modification time (the last argument given here to wp_enqueue_style). Alternative would be to use `wp_get_theme()->get('Version')` but it could lead to headaches when deploying incremental CSS changes. What do you think?


Aside, shouldn't the `style.css` to be at `assets/styles/style.css` instead of theme root to promote a neater folder structure, or is it better at theme root as WP theme standard?