### PR TITLE
fix: pass null to action calls for get_header and get_footer in Twig templates

### DIFF
--- a/views/layouts/base.twig
+++ b/views/layouts/base.twig
@@ -38,6 +38,6 @@
             {% include 'partials/footer.twig' %}
         {% endblock %}
         {{ function('wp_footer') }}
-        {% do action('get_footer') %}
+        {% do action('get_footer', null) %}
     </body>
 </html>

--- a/views/layouts/base.twig
+++ b/views/layouts/base.twig
@@ -38,6 +38,6 @@
             {% include 'partials/footer.twig' %}
         {% endblock %}
         {{ function('wp_footer') }}
-        {% do action('get_footer', null) %}
+        {% do action('get_footer', null, []) %}
     </body>
 </html>

--- a/views/partials/head.twig
+++ b/views/partials/head.twig
@@ -3,6 +3,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="author" href="{{ site.theme.link }}/humans.txt" />
     <link rel="profile" href="http://gmpg.org/xfn/11" />
-    {% do action('get_header') %}
+    {% do action('get_header', null) %}
     {{ function('wp_head') }}
 </head>

--- a/views/partials/head.twig
+++ b/views/partials/head.twig
@@ -3,6 +3,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="author" href="{{ site.theme.link }}/humans.txt" />
     <link rel="profile" href="http://gmpg.org/xfn/11" />
-    {% do action('get_header', null) %}
+    {% do action('get_header', null, []) %}
     {{ function('wp_head') }}
 </head>


### PR DESCRIPTION
Related:

- #171

## Issue
get_header and get_footer calls can cause issues with QM.

## Solution

## Impact
Adding the null value and array valaue, fixes this.

## Usage Changes
no